### PR TITLE
Initial skeleton for C++ example/exercise code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Microsoft
+IndentWidth: 4
+ColumnLimit: 100

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,14 @@
+name: Check links in Markdown files
+on:
+  schedule:
+    - cron: "0 0 * * 1" # midnight every Monday
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,39 @@ jobs:
         with:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"
+
+  build:
+    name: Build all projects
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt update
+          sudo apt upgrade
+          sudo apt install build-essential cmake ninja
+
+      - name: Set up MSVC (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Install dependencies (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install cmake ninja
+
+      - name: Build all projects
+        run: |
+          # Configure: Use Ninja as build backend
+          cmake -B build -GNinja -DWARNINGS_AS_ERRORS=ON
+
+          # Build projects
+          cmake --build build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push, pull_request, release]
+
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pre-commit/action@v3.0.0
+
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        name: Check links in markdown files
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install dependencies (macOS)
         if: matrix.os == 'macos-latest'
-        run: brew install cmake ninja
+        run: brew install ninja
 
       - name: Build all projects
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt upgrade
-          sudo apt install build-essential cmake ninja
+          sudo apt install build-essential cmake ninja-build
 
       - name: Set up MSVC (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -1,0 +1,20 @@
+name: Pre-commit auto-update
+
+on:
+  schedule:
+    - cron: "0 0 * * 1" # midnight every Monday
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - uses: browniebroke/pre-commit-autoupdate-action@main
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-hooks
+          title: Update pre-commit hooks
+          commit-message: "chore: update pre-commit hooks"
+          body: Update versions of pre-commit hooks to latest version.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# VS Code
+.vscode/*
+!.vscode/extensions.json
+
 # Prerequisites
 *.d
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,17 @@
 *.exe
 *.out
 *.app
+
+# CMake
+**/build/*
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-json
+      - id: check-yaml
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.33.0
+    hooks:
+      - id: markdownlint
+        args: ["--disable", "MD013"]
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v16.0.6
+    hooks:
+      - id: clang-format
+        files: '.*\.(h|hpp|cpp)'
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+        files: '.*\.(json|yaml|yml)'

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["ms-vscode.cpptools-extension-pack"]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.11)
+project(UnitTestingCppExercises)
+include(cmake/UnitTestingCourseCommon.cmake)
+add_subdirectory(src/Chapter2)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 In order to run the examples in this repository, you need a C++ compiler (supporting
 C++14 or newer) and CMake (version 3.11 or newer).
 
+For this course, we will be using [GoogleTest], a popular and easy-to-use testing
+framework. If you compile your code against the GoogleTest libraries, you will have a
+test executable, which when run will execute your tests. CMake provides a convenient
+tool called [CTest] for executing your project's tests (with whatever framework you are
+using in a convenient manner), which also integrates with a variety of IDEs (see below).
+
 On Ubuntu, you can install your dependencies like this:
 
 ```sh
@@ -54,9 +60,6 @@ cd build
 ctest
 ```
 
-[CTest]:
-    https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html
-
 ## Building and testing projects with an IDE
 
 Nowadays, many popular IDEs, including Visual Studio and Visual Studio Code, provide
@@ -64,5 +67,8 @@ built-in support for CMake and CTest and will automatically configure your proje
 CMakeLists.txt file is discovered in its root. For Visual Studio Code, you will need the
 [CMake extension] installed.
 
+[GoogleTest]: https://google.github.io/googletest/
+[CTest]:
+    https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html
 [CMake extension]:
     https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# Accompanying code for Unit Testing C++ course
+
+## Prerequisites
+
+In order to run the examples in this repository, you need a C++ compiler (supporting
+C++14 or newer) and CMake (version 3.11 or newer).
+
+On Ubuntu, you can install your dependencies like this:
+
+```sh
+sudo apt install build-essential cmake
+```
+
+On macOS, you can install them with [Homebrew](https://brew.sh/):
+
+```sh
+brew install cmake
+```
+
+If you are using Visual Studio on Windows, you do not require any additional
+dependencies.
+
+## Building projects from the command line
+
+If you are doing this with Visual Studio on Windows, you will need to open the Visual
+Studio Developer Shell for this step.
+
+First, navigate to the project you wish to build, e.g.:
+
+```sh
+cd src/Chapter2
+```
+
+(If you wish to build all projects, you can just invoke CMake from the root directory of
+this repository.)
+
+Then you can build using CMake in the usual way:
+
+```sh
+cmake -B build
+cmake --build build/
+```
+
+## Running tests from the command line
+
+Once you have built your project, you can then run the tests by using [CTest], which is
+a helper program bundled with CMake:
+
+```sh
+# Enter build directory
+cd build
+
+# Run CTest
+ctest
+```
+
+[CTest]:
+    https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html
+
+## Building and testing projects with an IDE
+
+Nowadays, many popular IDEs, including Visual Studio and Visual Studio Code, provide
+built-in support for CMake and CTest and will automatically configure your project if a
+CMakeLists.txt file is discovered in its root. For Visual Studio Code, you will need the
+[CMake extension] installed.
+
+[CMake extension]:
+    https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools

--- a/cmake/UnitTestingCourseCommon.cmake
+++ b/cmake/UnitTestingCourseCommon.cmake
@@ -31,4 +31,6 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG v1.13.0
 )
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)

--- a/cmake/UnitTestingCourseCommon.cmake
+++ b/cmake/UnitTestingCourseCommon.cmake
@@ -1,0 +1,16 @@
+# Common CMake stuff to be used by different chapters. To make your own CMake project,
+# you will need to have this (or something similar) in your CMakeLists.txt file.
+
+# GoogleTest requires at least C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+enable_testing()
+
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.13.0
+)
+FetchContent_MakeAvailable(googletest)

--- a/cmake/UnitTestingCourseCommon.cmake
+++ b/cmake/UnitTestingCourseCommon.cmake
@@ -1,9 +1,19 @@
 # Common CMake stuff to be used by different chapters. To make your own CMake project,
 # you will need to have this (or something similar) in your CMakeLists.txt file.
 
+# Stop this file being included more than once
+include_guard(GLOBAL)
+
 # GoogleTest requires at least C++14
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Enable compiler warnings and standard conformance
+if(MSVC)
+    add_compile_options(/W4 /permissive-)
+else()
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
 enable_testing()
 

--- a/cmake/UnitTestingCourseCommon.cmake
+++ b/cmake/UnitTestingCourseCommon.cmake
@@ -11,8 +11,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Enable compiler warnings and standard conformance
 if(MSVC)
     add_compile_options(/W4 /permissive-)
+
+    if(WARNINGS_AS_ERRORS)
+        add_compile_options(/WX)
+    endif()
 else()
     add_compile_options(-Wall -Wextra -Wpedantic)
+
+    if(WARNINGS_AS_ERRORS)
+        add_compile_options(-Werror)
+    endif()
 endif()
 
 enable_testing()

--- a/src/Chapter2/CMakeLists.txt
+++ b/src/Chapter2/CMakeLists.txt
@@ -1,19 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 project(Chapter2)
-
-# GoogleTest requires at least C++14
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-enable_testing()
-
-include(FetchContent)
-FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.13.0
-)
-FetchContent_MakeAvailable(googletest)
+include(../../cmake/UnitTestingCourseCommon.cmake)
 
 add_executable(${PROJECT_NAME}_program program.cpp fibonacci.cpp)
 add_executable(${PROJECT_NAME}_test test.cpp fibonacci.cpp)

--- a/src/Chapter2/CMakeLists.txt
+++ b/src/Chapter2/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.11)
+project(Chapter2)
+
+# GoogleTest requires at least C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+enable_testing()
+
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.13.0
+)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(${PROJECT_NAME}_program program.cpp fibonacci.cpp)
+add_executable(${PROJECT_NAME}_test test.cpp fibonacci.cpp)
+target_link_libraries(
+    ${PROJECT_NAME}_test
+    GTest::gtest_main
+)
+
+include(GoogleTest)
+gtest_discover_tests(${PROJECT_NAME}_test)

--- a/src/Chapter2/CMakeLists.txt
+++ b/src/Chapter2/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(${PROJECT_NAME}_program program.cpp fibonacci.cpp)
 add_executable(${PROJECT_NAME}_test test.cpp fibonacci.cpp)
 target_link_libraries(
     ${PROJECT_NAME}_test
-    GTest::gtest_main
+    GTest::gtest
 )
 
 include(GoogleTest)

--- a/src/Chapter2/fibonacci.cpp
+++ b/src/Chapter2/fibonacci.cpp
@@ -1,0 +1,14 @@
+#include "fibonacci.hpp"
+
+// Returns the n-th term of the Fibonacci sequence.
+int recursive_fibonacci(int n)
+{
+    if (n <= 1)
+    {
+        return n;
+    }
+    else
+    {
+        return recursive_fibonacci(n - 1) + recursive_fibonacci(n - 2);
+    }
+}

--- a/src/Chapter2/fibonacci.hpp
+++ b/src/Chapter2/fibonacci.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+// Returns the n-th term of the Fibonacci sequence.
+int recursive_fibonacci(int n);

--- a/src/Chapter2/program.cpp
+++ b/src/Chapter2/program.cpp
@@ -1,0 +1,15 @@
+#include "fibonacci.hpp"
+#include <iostream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+    if (argc < 2)
+    {
+        std::cout << "Error: Must provide an integer as an argument\n";
+        return 1;
+    }
+
+    int n = std::stoi(argv[1]);
+    std::cout << "Fib(" << n << "): " << recursive_fibonacci(n) << "\n";
+}

--- a/src/Chapter2/test.cpp
+++ b/src/Chapter2/test.cpp
@@ -1,0 +1,23 @@
+#include "fibonacci.hpp"
+#include "gtest/gtest.h"
+#include <iostream>
+
+TEST(FibonacciTest, HandlesZeroInput)
+{
+    EXPECT_EQ(recursive_fibonacci(0), 0);
+}
+
+TEST(FibonacciTest, HandlesValueOneAsInput)
+{
+    EXPECT_EQ(recursive_fibonacci(1), 1);
+}
+
+TEST(FibonacciTest, HandlesPositiveInput)
+{
+    EXPECT_EQ(recursive_fibonacci(5), 5);
+}
+
+TEST(FibonacciTest, HandlesNegativeInput)
+{
+    EXPECT_EQ(recursive_fibonacci(-3), -3);
+}

--- a/src/Chapter2/test.cpp
+++ b/src/Chapter2/test.cpp
@@ -21,3 +21,9 @@ TEST(FibonacciTest, HandlesNegativeInput)
 {
     EXPECT_EQ(recursive_fibonacci(-3), -3);
 }
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The code I've used for the first example/exercise is the one used by @lkr-ind for Chapter 2 of the course. I had to reorganise things a bit to make it fit into a CMake project, but the code itself should be the same.

I've also added a top-level CMakeLists.txt file to the project. One reason is that it's useful for CI purposes, but a top-level CMakeLists.txt file is also needed for IDEs like Visual Studio Code to correctly load the project for things like intellisense etc. Rather pleasingly, if you do this then the test suite is also nicely integrated with the IDE:

![image](https://github.com/ImperialCollegeLondon/unit_testing_Cpp_exercises/assets/23149834/5e5048bf-efe2-490c-b74a-9c59cd19806e)

The common CMake code currently lives in its own file under the `cmake/` folder, but if students want to make their own project they would have to copy and paste its contents into their own CMakeLists.txt

I've also enabled CI for the repo so that we can check that all the example code compiles on Windows, Linux and macOS and that the files are properly formatted etc. Currently I'm *not* running the tests, as I wasn't sure whether we'd want some failing tests in the repository as an exercise. In that case we could mark the tests as expected to fail (assuming you can do this with GoogleTest), but that might confuse students.

I've stuck some text in a readme, but some/all of it could also just go directly into the course material, depending on how we want to organise things.

Close https://github.com/ImperialCollegeLondon/unit_testing_Cpp/issues/7